### PR TITLE
Update 06-send-transaction.mdx

### DIFF
--- a/docs/build-with-sequence/06-send-transaction.mdx
+++ b/docs/build-with-sequence/06-send-transaction.mdx
@@ -9,7 +9,8 @@ const transaction = {
   value: 1000000000000000000
 }
 
-const txnResponse = await wallet.sendTransaction(transaction)
+const signer = await wallet.getSigner()
+const txnResponse = await signer.sendTransaction(transaction)
 console.log(txnResponse)
 
 // wait for the transaction to be mined


### PR DESCRIPTION
wallet.sendTransaction gives an error "wallet.sendTransaction is not a function". 

Solution is to use "signer.sendTransaction" and "signer" is received via "wallet.getSigner()"