### PR TITLE
Add Guard Key link and fix spelling of configuration

### DIFF
--- a/docs/private-keys/03-web3-login.mdx
+++ b/docs/private-keys/03-web3-login.mdx
@@ -7,7 +7,7 @@ ETA **Q1-Q2, 2022**.
 
 Users can create a sequence wallet without having to use an email address or social login. 
 
-If this path was chosen, users wallets would only be controlled by session keys stored on their devices and a [backup key](backup-key). This also implies that these wallets are not associated with a Guard Key [**LINK**] either and hence users are fully responsible for ensuring they do not lose access to their keys.
+If this path was chosen, users wallets would only be controlled by session keys stored on their devices and a [backup key](backup-key). This also implies that these wallets are not associated with a [Guard Key](social-login-wallets#guard-key) either and hence users are fully responsible for ensuring they do not lose access to their keys.
 
 
 ## Wallet Creation
@@ -17,7 +17,7 @@ When creating a wallet using the web3 login, users will create a session key tha
 
 ## Adding New Devices
 
-Web3 login users can access their wallet on other devices by having one of their already authorized device scan a QR code on the new device. The QR code contains the address of the session key on the new device that the already authorized device will add to the wallet configutation. This ensures that users never need to enter their seedphrase to connect to a new device if they still have access to an already authorized device.
+Web3 login users can access their wallet on other devices by having one of their already authorized device scan a QR code on the new device. The QR code contains the address of the session key on the new device that the already authorized device will add to the wallet configuration. This ensures that users never need to enter their seedphrase to connect to a new device if they still have access to an already authorized device.
 
 
 ## Recovering a Wallet


### PR DESCRIPTION
## Description
- Adds a link to https://docs.sequence.xyz/private-keys/social-login-wallets#guard-key based on missing LINK on page
- Fixes spelling configutation -> configuration 