### PR TITLE
Change wallet to address

### DIFF
--- a/docs/wallet-contracts/05-modules-and-updates.mdx
+++ b/docs/wallet-contracts/05-modules-and-updates.mdx
@@ -39,7 +39,7 @@ The wallet implementation is stored on the contract storage slot defined by the 
 ```js
 import "ethers"
 
-const wallet = "0x596af90cecdbf9a768886e771178fd5561dd27ab"
+const address = "0x596af90cecdbf9a768886e771178fd5561dd27ab"
 const provider = new ethers.providers.JsonRpcProvider("http://localhost:8545")
 
 // Read storage slot address(address)


### PR DESCRIPTION
## Description
- Change `wallet` to `address` in block of code that uses `address` for the variable name instead of `wallet`