### PR TITLE
Added Sardine and PayTrie to onramps list

### DIFF
--- a/docs/03-wallet/07-fiat-support/01-fiat-on-ramps.mdx
+++ b/docs/03-wallet/07-fiat-support/01-fiat-on-ramps.mdx
@@ -3,12 +3,14 @@ slug: /fiat-on-ramps
 ---
 
 # Fiat On-Ramps
-Sequence Wallet allows users to purchase cryptocurrencies directly with their credit card and debit card via on-ramp providers. Currently Sequence supports 4 on-ramp providers;
+Sequence Wallet allows users to purchase cryptocurrencies directly with their credit card and debit card via on-ramp providers. Currently Sequence supports 6 on-ramp providers;
 
 - [Moonpay](https://www.moonpay.com/)
 - [Wyre](https://www.sendwyre.com/)
 - [Ramp](https://ramp.network/)
 - [UPI via Onmeta](https://onmeta.in/)
+- [Sardine](https://www.sardine.ai/)
+- [PayTrie](https://paytrie.com/)
 
 Only providers that support the region the users are in will be displayed. 
 


### PR DESCRIPTION
Added Sardine and PayTrie to the list of supported on-ramps and upped the count from 4 to 6