### PR TITLE
Increased `max-width` of doc content from `580px` to `850px`

### DIFF
--- a/src/theme/DocCategoryGeneratedIndexPage/index.jsx
+++ b/src/theme/DocCategoryGeneratedIndexPage/index.jsx
@@ -30,7 +30,7 @@ function DocCategoryGeneratedIndexPageContent({ categoryGeneratedIndex }) {
 
   return (
     <div className="flex">
-      <div className="w-full max-w-[580px] mx-auto">
+      <div className="w-full max-w-[850px] mx-auto">
         <DocVersionBanner />
         <DocBreadcrumbs />
         <DocVersionBadge />

--- a/src/theme/DocItem/Layout/index.jsx
+++ b/src/theme/DocItem/Layout/index.jsx
@@ -41,7 +41,7 @@ export default function DocItemLayout({ children }) {
     <div className="row">
       <div className={clsx('col')}>
         <DocVersionBanner />
-        <div className="w-full max-w-[580px] mx-auto">
+        <div className="w-full max-w-[850px] mx-auto">
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />


### PR DESCRIPTION
I think the current document content width is too small, so I have increased the width to fill up space. lmk if there's any issues. 

## FROM
![image](https://user-images.githubusercontent.com/55626361/221346258-0479112e-0e63-4fba-af4f-ad183fab1d67.png)

## TO
![image](https://user-images.githubusercontent.com/55626361/221346298-31752a42-d673-4622-bee9-8a82db322d11.png)

