### PR TITLE
Instructions for using the rainbowkit plugin with older wagmi versions

### DIFF
--- a/docs/03-wallet/05-connectors/02-rainbow-kit.mdx
+++ b/docs/03-wallet/05-connectors/02-rainbow-kit.mdx
@@ -69,6 +69,16 @@ See [the example app](https://github.com/0xsequence/demo-dapp-wagmi-next/tree/us
 See [this section](https://docs.sequence.xyz/wallet/connectors/FAQ/#how-do-i-use-a-wallet-library-and-connector-with-nextjs-using-the-pages-directory-all-versions-of-nextjs) for an explanation on using Wagmi or Wagmi-based libaries with `pages` router.  
 See [the example app](https://github.com/0xsequence/demo-dapp-wagmi-next/tree/mount-hook) which uses the `pages` router structure.  
 
+## Using older versions of Wagmi (<= 0.12.x)
+If you are using an older version of Wagmi (<= 0.12.x), which is based on ethers instead of viem, use the following command to install the appropriate version of the wagmi connector:
+
+```shell
+npm install @0xsequence/wagmi-connector@1.0 0xsequence ethers
+```
+or
+```shell
+yarn add @0xsequence/wagmi-connector@1.0 0xsequence ethers
+```
 
 ## Examples
 


### PR DESCRIPTION
- Added instructions for using the rainbowkit plugin with older wagmi versions