### PR TITLE
fixed kit docs url

### DIFF
--- a/docs/03-wallet/05-connectors/02-kit/01-overview.mdx
+++ b/docs/03-wallet/05-connectors/02-kit/01-overview.mdx
@@ -1,5 +1,5 @@
 ---
-slug: kit/overview
+slug: overview
 title: Sequence Kit Documentation
 ---
 


### PR DESCRIPTION
Fixed kit's url in docs.
 https://docs.sequence.xyz/wallet/connectors/kit/kit/overview becomes  https://docs.sequence.xyz/wallet/connectors/kit/overview