### PR TITLE
Add Builder Overviews

### DIFF
--- a/docs/075-guides/001-overview.mdx
+++ b/docs/075-guides/001-overview.mdx
@@ -1,0 +1,45 @@
+---
+slug: /guides/overview
+---
+
+# Sequence Builder guides
+
+import CardList from '/src/components/CardList'
+
+<CardList items={[
+  {
+    title: "🔑 Access Key Management",
+    description: 'Learn how to get access to your API keys in Builder',
+    route: '/getting-started/get-access-key-in-builder',
+  },
+  {
+    title: '🔖 Deploy a Contract',
+    description: 'Learn how to deploy an item collection contract in Builder',
+    route: '/guides/deploy-an-item-collection-contract',
+  },
+  {
+    title: '⚡️ Sponsor contract gas',
+    description: 'Learn how to sponsor gas for a contract in Builder',
+    route: '/guides/sponsor-contract-gas-tank',
+  },
+  {
+    title: '⛽️ Refill the Gas Tank',
+    description: 'Learn how to pay for gas in the Gas Tank in Builder',
+    route: '/guides/refill-gas-tank',
+  },
+  {
+    title: '🎖️ Mint In-Game Items and Achievements',
+    description: 'Learn how to mint in-game items from a contract in Builder',
+    route: '/guides/mint-items-from-ERC1155',
+  },
+  {
+    title: '🪙  Mint In-Game Currency',
+    description: 'Learn how to mint in-game currency from a contract in Builder',
+    route: '/guides/mint-currency-from-ERC20',
+  },
+  {
+    title: '💎  Mint Digital Collectibles',
+    description: 'Learn how to mint collectibles from a contract in Builder',
+    route: '/guides/mint-collectibles-from-ERC721',
+  },
+]} />

--- a/docs/075-guides/001-overview.mdx
+++ b/docs/075-guides/001-overview.mdx
@@ -2,14 +2,14 @@
 slug: /guides/overview
 ---
 
-# Sequence Builder guides
+# Sequence Builder Guides
 
 import CardList from '/src/components/CardList'
 
 <CardList items={[
   {
     title: "🔑 Access Key Management",
-    description: 'Learn how to get access to your API keys in Builder',
+    description: 'Learn how to access your API keys in Builder',
     route: '/getting-started/get-access-key-in-builder',
   },
   {
@@ -18,7 +18,7 @@ import CardList from '/src/components/CardList'
     route: '/guides/deploy-an-item-collection-contract',
   },
   {
-    title: '⚡️ Sponsor contract gas',
+    title: '⚡️ Sponsor Contract Gas',
     description: 'Learn how to sponsor gas for a contract in Builder',
     route: '/guides/sponsor-contract-gas-tank',
   },

--- a/docs/075-guides/010-signup-and-create-a-project.mdx
+++ b/docs/075-guides/010-signup-and-create-a-project.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/signup-and-create-a-project
+slug: /guides/signup-and-create-a-project
 ---
 
 # Getting Started: Signup and create a project in Builder
@@ -86,37 +86,37 @@ import CardList from '/src/components/CardList'
 <CardList items={[
   {
     title: "🔑 Access Key Management",
-    description: 'get access to your API keys in Builder',
+    description: 'Learn how to get access to your API keys in Builder',
     route: '/getting-started/get-access-key-in-builder',
   },
   {
     title: '🔖 Deploy a Contract',
-    description: 'deploy an item collection contract in Builder',
-    route: '/builder/deploy-an-item-collection-contract',
+    description: 'Learn how to deploy an item collection contract in Builder',
+    route: '/guides/deploy-an-item-collection-contract',
   },
   {
     title: '⚡️ Sponsor contract gas',
-    description: 'sponsor gas for a contract in Builder',
-    route: '/builder/sponsor-contract-gas-tank',
+    description: 'Learn how to sponsor gas for a contract in Builder',
+    route: '/guides/sponsor-contract-gas-tank',
   },
   {
     title: '⛽️ Refill the Gas Tank',
-    description: 'Pay for gas in the Gas Tank in Builder',
-    route: '/builder/refill-gas-tank',
+    description: 'Learn how to pay for gas in the Gas Tank in Builder',
+    route: '/guides/refill-gas-tank',
   },
   {
     title: '🎖️ Mint In-Game Items and Achievements',
-    description: 'mint in-game items from a contract in Builder',
-    route: '/builder/mint-items-from-ERC1155',
+    description: 'Learn how to mint in-game items from a contract in Builder',
+    route: '/guides/mint-items-from-ERC1155',
   },
   {
     title: '🪙  Mint In-Game Currency',
-    description: 'mint in-game currency from a contract in Builder',
-    route: '/builder/mint-currency-from-ERC20',
+    description: 'Learn how to mint in-game currency from a contract in Builder',
+    route: '/guides/mint-currency-from-ERC20',
   },
   {
     title: '💎  Mint Digital Collectibles',
-    description: 'mint collectibles from a contract in Builder',
-    route: '/builder/mint-collectibles-from-ERC721',
+    description: 'Learn how to mint collectibles from a contract in Builder',
+    route: '/guides/mint-collectibles-from-ERC721',
   },
 ]} />

--- a/docs/075-guides/010-signup-and-create-a-project.mdx
+++ b/docs/075-guides/010-signup-and-create-a-project.mdx
@@ -2,7 +2,7 @@
 slug: /guides/signup-and-create-a-project
 ---
 
-# Getting Started: Signup and create a project in Builder
+# Getting Started: Signup and Create a Project in Builder
 
 Signing up and creating a project is easy to do with Sequence Builder and should take you less than a minute. In this tutorial, we will help you sign up for Builder and then create your first project. 
 

--- a/docs/075-guides/200-deploy-an-item-collection-contract.mdx
+++ b/docs/075-guides/200-deploy-an-item-collection-contract.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/deploy-an-item-collection-contract
+slug: /guides/deploy-an-item-collection-contract
 ---
 
 # How to deploy an item collection contract

--- a/docs/075-guides/200-deploy-an-item-collection-contract.mdx
+++ b/docs/075-guides/200-deploy-an-item-collection-contract.mdx
@@ -2,7 +2,7 @@
 slug: /guides/deploy-an-item-collection-contract
 ---
 
-# How to deploy an item collection contract
+# How to Deploy an Item Collection Contract
 
 This guide walks through how to setup and deploy a contract on Builder. If you haven't yet done so, make sure you have [signed up for Builder and created a Project](https://docs.sequence.xyz/signup-and-create-a-project).
 

--- a/docs/075-guides/400-sponsor-contract-in-gas-tank.mdx
+++ b/docs/075-guides/400-sponsor-contract-in-gas-tank.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/sponsor-contract-gas-tank
+slug: /guides/sponsor-contract-gas-tank
 ---
 
 # How to sponsor gas for a contract in Builder

--- a/docs/075-guides/400-sponsor-contract-in-gas-tank.mdx
+++ b/docs/075-guides/400-sponsor-contract-in-gas-tank.mdx
@@ -2,7 +2,7 @@
 slug: /guides/sponsor-contract-gas-tank
 ---
 
-# How to sponsor gas for a contract in Builder
+# How to Sponsor Gas for a Contract in Builder
 
 Sponsoring gas for your web3 game enhances the player's experience, encourages in-game transactions, and reduces friction for onboarding new users.
 

--- a/docs/075-guides/401-refill-gas-tank.mdx
+++ b/docs/075-guides/401-refill-gas-tank.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/refill-gas-tank
+slug: /guides/refill-gas-tank
 ---
 
 

--- a/docs/075-guides/401-refill-gas-tank.mdx
+++ b/docs/075-guides/401-refill-gas-tank.mdx
@@ -3,7 +3,7 @@ slug: /guides/refill-gas-tank
 ---
 
 
-# How to refill the Gas Tank in Builder
+# How to Refill the Gas Tank in Builder
 
 In this walkthrough, we will show you how to refill your gas tank in Builder with a credit card. Gas is used to [sponsor gas for contracts](https://docs.sequence.xyz/builder/sponsor-contract-gas-tank) and manage your relayers, so it's important to know how to keep your tank full.
 

--- a/docs/075-guides/900-mint-items-from-ERC1155.mdx
+++ b/docs/075-guides/900-mint-items-from-ERC1155.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/mint-items-from-ERC1155
+slug: /guides/mint-items-from-ERC1155
 ---
 
 # How to mint in-game items and achievements in Builder

--- a/docs/075-guides/900-mint-items-from-ERC1155.mdx
+++ b/docs/075-guides/900-mint-items-from-ERC1155.mdx
@@ -2,7 +2,7 @@
 slug: /guides/mint-items-from-ERC1155
 ---
 
-# How to mint in-game items and achievements in Builder
+# How to Mint in-game Items and Achievements in Builder
 
 ## Introduction
 

--- a/docs/075-guides/902-mint-collectibles-from-ERC721.mdx
+++ b/docs/075-guides/902-mint-collectibles-from-ERC721.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/mint-collectibles-from-ERC721
+slug: /guides/mint-collectibles-from-ERC721
 ---
 
 # How to mint digital collectibles in Builder

--- a/docs/075-guides/902-mint-collectibles-from-ERC721.mdx
+++ b/docs/075-guides/902-mint-collectibles-from-ERC721.mdx
@@ -2,7 +2,7 @@
 slug: /guides/mint-collectibles-from-ERC721
 ---
 
-# How to mint digital collectibles in Builder
+# How to Mint Digital Collectibles in Builder
 
 ## Introduction
 

--- a/docs/075-guides/903-mint-currency-from-ERC20.mdx
+++ b/docs/075-guides/903-mint-currency-from-ERC20.mdx
@@ -2,7 +2,7 @@
 slug: /guides/mint-currency-from-ERC20
 ---
 
-# How to mint in-game currency in Builder
+# How to Mint in-game Currency in Builder
 
 ## Introduction
 

--- a/docs/075-guides/903-mint-currency-from-ERC20.mdx
+++ b/docs/075-guides/903-mint-currency-from-ERC20.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /builder/mint-currency-from-ERC20
+slug: /guides/mint-currency-from-ERC20
 ---
 
 # How to mint in-game currency in Builder

--- a/docs/075-guides/_category_.json
+++ b/docs/075-guides/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Guides",
+  "link": {
+    "type": "doc",
+    "id": "guides/overview"
+  }
+}

--- a/docs/100-builder/050-contracts.mdx
+++ b/docs/100-builder/050-contracts.mdx
@@ -1,0 +1,19 @@
+---
+title: Contracts
+hide_title: true
+slug: /builder/contracts
+---
+
+# Welcome to Contracts in Builder
+
+Sequence Builder simplifies smart contract deployment and management with a suite of user-friendly features. Import or deploy a smart contract into the contracts dashboard and interact directly with your contract.
+
+##### What are my deployment options?
+Deployment of contracts with Sequence Builder is simplified through a streamlined process directly within our dashboard. Choose from a contract starts by providing a list of common options to use (ERC1155, ERC721, ERC20), and also gives you the option to search for and upload your own custom contract and deploy it directly.
+
+##### What contract interactions can I do?
+Sequence Builder provides a comprehensive contract dashboard, allowing users to explore and monitor various smart contract activities like transactions, balance, and tokens. Performing read and executing write operations on contracts becomes effortless, making it easy for actions such as minting.
+
+## Watch a Contract be deployed with Builder
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/g7jthpR-bCM?si=15sHW-c9kJhaFPyr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/050-contracts.mdx
+++ b/docs/100-builder/050-contracts.mdx
@@ -4,7 +4,7 @@ hide_title: true
 slug: /builder/contracts
 ---
 
-# Welcome to Contracts in Builder
+# Contracts in Builder
 
 Sequence Builder simplifies smart contract deployment and management with a suite of user-friendly features. Import or deploy a smart contract into the contracts dashboard and interact directly with your contract.
 

--- a/docs/100-builder/100-wallet-sdks.mdx
+++ b/docs/100-builder/100-wallet-sdks.mdx
@@ -4,7 +4,7 @@ hide_title: true
 slug: /builder/wallet-sdks
 ---
 
-# Welcome to Wallet SDKs in Builder
+# Wallet SDKs in Builder
 Sequence Builder offers multiple SDK options for integrating Sequence Wallet into your project.
 
 ### How can I integrate a Wallet into my game with these options?
@@ -26,7 +26,5 @@ All integrations provide non-custodial smart contract wallets with account abstr
 **Unity SDK** and **Unreal SDK** give you the advantages of integrating a Sequence Wallet directly into your game.
 
 ## Watch a Wallet integration using SequenceKit with Builder
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/2uaXwwbZUhk?si=N2t45e-1FsT5QTNf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/2uaXwwbZUhk?si=N2t45e-1FsT5QTNf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/100-wallet.mdx
+++ b/docs/100-builder/100-wallet.mdx
@@ -4,34 +4,29 @@ hide_title: true
 slug: /builder/wallet-sdks
 ---
 
-# Welcome to Wallet SDK's in Builder
-Sequence Builder offers multiple options for integrating Sequence Wallet into your project. You can use SequenceKit to connect a Sequence Wallet or choose one of our SDKs.
+# Welcome to Wallet SDKs in Builder
+Sequence Builder offers multiple SDK options for integrating Sequence Wallet into your project.
 
-##### How can I integrate a Wallet into my game with these options?
-With SequenceKit, you can utilize the interface within this Builder section. Simply input the wallet details, such as networks and authentication preferences, then click 'save.' The interface will generate the necessary code and present it to you as a code snippet. For additional information and the next steps, watch the tutorial below.
+### How can I integrate a Wallet into my game with these options?
+In the Wallets SDK section of Builder, simply select **SequenceKit**, input wallet details, click 'save', and code snippets will be generated for you to use. The same can be done for **Web SDK** (watch the tutorial below for additional guidance). **Unity SDK** and **Unreal SDK** will help you integrate the same way, but by interacting their respective game engines. Note that both SDKs are receiving updates and will be available shortly.
 
-When utilizing our SDKs, you have a few options. The first SDK choice involves using a Web SDK. Similar to the SequenceKit option, you can input specific details and receive a code snippet for your wallet.
+### What are the differences between these options?
+**Web SDK** and **SequenceKit** both deploy our Universal Wallet. They integrate differently, but offer the similar wallet benefits. However, **SequenceKit** is also a wallet connector, providing additional benefits.
 
-The Next option is to utilize either the Unreal SDK or Unity SDK. Please note that neither is currently live, but both will be available soon.
+**SequenceKit** is a powerful wallet connector, enabling existing wallet users across web3 to connect a wallet - vastly improving their user experience through embedded item views, integrated NFT checkout, and seamless wallet creation.
 
-##### What are the differences between these options?
-All these options offer non-custodial smart contract wallets with account abstraction features you expect.
+**The Unity SDK** integrates Wallet & Indexer functionality into games developed with the Unity Engine. Similarly, the **Unreal SDK** is an integration for games built with the Unreal Engine.
 
-SequenceKit is wallet connector. You start by creating a Sequence Wallet, then you integrate SequenceKit into it. Integrating through SequenceKit comes with a few useful benefits.
+### What are the benefits of each and how can I leverage them?
 
-Web SDK
+All integrations provide non-custodial smart contract wallets with account abstraction benefits, including email and social login, gasless transactions, and more.
 
-The Unity SDK integrates Wallet & Indexer functionality into games developed with the Unity Engine. Similarly, the Unreal SDK is an integration for games built with the Unreal Engine.
+**SequenceKit** benefits from also being a wallet connector, which you can leverage to cater to both existing wallet holders and millions of potential new users. The embedded wallet views, integrated NFT checkout, and seamless wallet creation ensure that users never need to leave the game or app.
 
-##### What the benefits of each option and how can I leverage these benefits?
-All of these options also come with a couple of benefits for all our smart contract wallets, like email or social account logins and gas sponsoring and relayer options.
-
-SequenceKit offers some unique benefits. As a connector, it supports other web3 wallets. By leveraging you can cater to both existing wallet holders and millions of potential new users. SequenceKit also provides embedded wallet views so that users don’t need to leave the game or app.
-
-Web SDK
-
-Unity SDK and Unreal SDK give you the advantages of integrating a Sequence Wallet directly into the game.
+**Unity SDK** and **Unreal SDK** give you the advantages of integrating a Sequence Wallet directly into your game.
 
 ## Watch a Wallet integration using SequenceKit with Builder
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/2uaXwwbZUhk?si=N2t45e-1FsT5QTNf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/2uaXwwbZUhk?si=N2t45e-1FsT5QTNf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/100-wallet.mdx
+++ b/docs/100-builder/100-wallet.mdx
@@ -1,0 +1,37 @@
+---
+title: Wallet SDKs
+hide_title: true
+slug: /builder/wallet-sdks
+---
+
+# Welcome to Wallet SDK's in Builder
+Sequence Builder offers multiple options for integrating Sequence Wallet into your project. You can use SequenceKit to connect a Sequence Wallet or choose one of our SDKs.
+
+##### How can I integrate a Wallet into my game with these options?
+With SequenceKit, you can utilize the interface within this Builder section. Simply input the wallet details, such as networks and authentication preferences, then click 'save.' The interface will generate the necessary code and present it to you as a code snippet. For additional information and the next steps, watch the tutorial below.
+
+When utilizing our SDKs, you have a few options. The first SDK choice involves using a Web SDK. Similar to the SequenceKit option, you can input specific details and receive a code snippet for your wallet.
+
+The Next option is to utilize either the Unreal SDK or Unity SDK. Please note that neither is currently live, but both will be available soon.
+
+##### What are the differences between these options?
+All these options offer non-custodial smart contract wallets with account abstraction features you expect.
+
+SequenceKit is wallet connector. You start by creating a Sequence Wallet, then you integrate SequenceKit into it. Integrating through SequenceKit comes with a few useful benefits.
+
+Web SDK
+
+The Unity SDK integrates Wallet & Indexer functionality into games developed with the Unity Engine. Similarly, the Unreal SDK is an integration for games built with the Unreal Engine.
+
+##### What the benefits of each option and how can I leverage these benefits?
+All of these options also come with a couple of benefits for all our smart contract wallets, like email or social account logins and gas sponsoring and relayer options.
+
+SequenceKit offers some unique benefits. As a connector, it supports other web3 wallets. By leveraging you can cater to both existing wallet holders and millions of potential new users. SequenceKit also provides embedded wallet views so that users don’t need to leave the game or app.
+
+Web SDK
+
+Unity SDK and Unreal SDK give you the advantages of integrating a Sequence Wallet directly into the game.
+
+## Watch a Wallet integration using SequenceKit with Builder
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/2uaXwwbZUhk?si=N2t45e-1FsT5QTNf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/150-gas-tank.mdx
+++ b/docs/100-builder/150-gas-tank.mdx
@@ -4,7 +4,7 @@ hide_title: true
 slug: /builder/gas-tank
 ---
 
-# Welcome to the Gas Tank in Builder
+# Gas Tank in Builder
 
 Sequence wallets are controlled by smart contracts, enabling transaction fees to be abstracted away from users, a concept known in web3 as *gas*. With Sequence Builder's Gas Tank, you have a streamlined process for sponsoring gas for your users.
 

--- a/docs/100-builder/150-gas-tank.mdx
+++ b/docs/100-builder/150-gas-tank.mdx
@@ -1,0 +1,24 @@
+---
+title: Gas Tank
+hide_title: true
+slug: /builder/gas-tank
+---
+
+# Welcome to the Gas Tank in Builder
+
+Sequence wallets are controlled by smart contracts, enabling transaction fees to be abstracted away from users, a concept known in web3 as *gas*. With Sequence Builder's Gas Tank, you have a streamlined process for sponsoring gas for your users.
+
+##### Why would I want to sponsor gas for my game?
+Obtaining the crypto needed to cover fees poses a challenge for traditional gamers. Sponsoring gas on their behalf solves this problem.    
+
+Gas sponsoring in a web3 game provides seamless onboarding by removing gas fees, making transactions efficient and cost-effective for trading virtual assets in various in-game activities. This creates a more enjoyable gaming experience, fostering player loyalty and community engagement.
+
+##### Sponsoring gas with the Gas Tank
+Sponsoring gas on contracts is easy, and can be done either by searching and adding a contract or selecting a contract that you have already deployed on a project. Project owners also have control over the contracts they sponsor, allowing them to temporarily disable a sponsor for a specific contract by toggling it off and updating the sponsor settings.
+
+There are a few options to fund sponsored gas, including a credit card checkout that makes paying for gas simple. 
+
+
+## Watch the Gas Tank in action in Builder
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/tDn4nd9Mi-c?si=xdAUBb1_hGusNAFJ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/200-node-gateway.mdx
+++ b/docs/100-builder/200-node-gateway.mdx
@@ -4,7 +4,7 @@ hide_title: true
 slug: /builder/node-gateway
 ---
 
-# Welcome to the Node Gateway in Builder
+# Node Gateway in Builder
 
 Sequence Builder offers a comprehensive Node Gateway dashboard that provides you with all the information needed to manage your node infrastructure, from compatibility with your favorite Web3 module to your requirement for real-time performant data for your game.
 

--- a/docs/100-builder/200-node-gateway.mdx
+++ b/docs/100-builder/200-node-gateway.mdx
@@ -1,0 +1,21 @@
+---
+title: Node Gateway
+hide_title: true
+slug: /builder/node-gateway
+---
+
+# Welcome to the Node Gateway in Builder
+
+Sequence Builder offers a comprehensive Node Gateway dashboard that provides you with all the information needed to manage your node infrastructure, from compatibility with your favorite Web3 module to your requirement for real-time performant data for your game.
+
+##### What kind of performance can I expect for my game?
+Sequence Node Gateway is engineered to power your gaming infrastructure. Node Gateway aggregates multiple node providers, auto-switching between them to ensure correct and in sync data availability — giving you the assurance that your decentralized applications run smoothly with low latency for your players.
+
+No need to worry about peak traffic – our node infrastructure is robust, offering higher scalability and fault tolerance. Additionally, we provide automatic node failure detection and recovery.
+
+##### What can you do to simplify the integration process for me?
+We've designed our dashboard to automatically generate API access keys and URLs for each network you have enabled in settings. This makes it easy to import the URL into your preferred Web3 npm module. Additionally, our dashboard makes it easy to monitor your compute usage and credit consumption.
+
+## Watch a Node Gateway integration
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/SPAbHTMNjL4?si=Y_EQn3Sywh9e5WXy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/250-marketplaces.mdx
+++ b/docs/100-builder/250-marketplaces.mdx
@@ -4,7 +4,7 @@ hide_title: true
 slug: /builder/marketplaces
 ---
 
-# Welcome to Marketplaces in Builder
+# Marketplaces in Builder
 
 Sequence Builder provides game builders with a white-label marketplace that can be launched in seconds. With Builder, you can customize your marketplace and integrate it directly into your game experience.
 

--- a/docs/100-builder/250-marketplaces.mdx
+++ b/docs/100-builder/250-marketplaces.mdx
@@ -1,0 +1,21 @@
+---
+title: Marketplaces
+hide_title: true
+slug: /builder/marketplaces
+---
+
+# Welcome to Marketplaces in Builder
+
+Sequence Builder provides game builders with a white-label marketplace that can be launched in seconds. With Builder, you can customize your marketplace and integrate it directly into your game experience.
+
+##### Why would I want my own Marketplace for my web3 game?
+Builder gives you full control over everything in your marketplace, from enforcing royalties (with ERC-2981) to choosing the best trading mechanism for your community, setting fees, and more. You can also aggregate listings from major platforms like OpenSea or LooksRare, providing you with the benefit of existing liquidity without relinquishing control of the gaming experience.
+
+Speaking of the gaming experience, you can customize your integration to place your marketplace anywhere within your players' game journey. You can even take it a step further by utilizing marketplace APIs to craft a dynamic gaming experience that responds to marketplace activity.
+
+##### What kind of customization can I do?
+Being able to seamlessly integrate your marketplace into your gaming experience means players never even have to leave the game to use the marketplace. Use all the custom layouts and design elements you need for your experience and brand. In addition to the embedding options, you can also host your marketplace on its own URL, giving you even more flexibility to craft the best experience possible.
+
+## Watch a Marketplace be launched in minutes
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ZVMw4bHgrJ4?si=tXc2VqWU8wE_dWtU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/300-indexer.mdx
+++ b/docs/100-builder/300-indexer.mdx
@@ -4,7 +4,7 @@ hide_title: true
 slug: /builder/indexer
 ---
 
-# Welcome to Indexer in Builder
+# Indexer in Builder
 
 Sequence Builder equips game builders with an indexer that collects data from the following networks: Ethereum (and Sepolia), Optimism, Base, Gnosis Chain, Polygon (and Polygon Mumbai), Polygon zkEVM, Arbitrum One, Arbitrum Nova, Gnosis Chain, BNB Smart Chain (and Smart Chain Testnet), Avalanche (and Avalanche Testnet), Oasys Homeverse (and Oasys Homeverse Testnet).
 

--- a/docs/100-builder/300-indexer.mdx
+++ b/docs/100-builder/300-indexer.mdx
@@ -1,0 +1,27 @@
+---
+title: Indexer
+hide_title: true
+slug: /builder/indexer
+---
+
+# Welcome to Indexer in Builder
+
+Sequence Builder equips game builders with an indexer that collects data from the following networks: Ethereum (and Sepolia), Optimism, Base, Gnosis Chain, Polygon (and Polygon Mumbai), Polygon zkEVM, Arbitrum One, Arbitrum Nova, Gnosis Chain, BNB Smart Chain (and Smart Chain Testnet), Avalanche (and Avalanche Testnet), Oasys Homeverse (and Oasys Homeverse Testnet).
+
+#### What data can I query for my game?
+Builder takes the stress out of gathering on-chain data for your game. Simply select the data you want from the indexer, and it generates the necessary code in snippets.
+
+Fetch different kinds of data from the indexer:
+- tokens and collectibles owned by any wallet
+- total supply for any token or collectible
+- the transaction and transfer history for any wallet address
+- contract metadata for any token or collection
+- metadata for any collectible
+- balance change events for any token or collection
+
+#### How much code will I have to write to query?
+Sequence Indexer offers several features that level-up your on-chain data capabilities without writing a line of code. It boasts a user-friendly interface that you can use to fetch important data, like the tokens owned by a specific wallet under a specific contract, for instance.
+
+## Watch the Indexer grab on-chain data
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/VwHn_BYiFYs?si=hvpyCxtVbtcfUH0s" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/100-builder/_category_.json
+++ b/docs/100-builder/_category_.json
@@ -1,7 +1,7 @@
 {
-    "label": "Builder",
-    "link": {
-      "type": "doc",
-      "id": "builder/overview"
-    }
+  "label": "Builder",
+  "link": {
+    "type": "doc",
+    "id": "builder/overview"
   }
+}


### PR DESCRIPTION
- create a **Guides** section in docs
- move all guides out of **Builder** and into **Guides** section
- write overviews for the following, put them in **Builder** section
  - Contracts overview
  - Wallet SDKs overview
  - Gas Tank overview
  - Node Gateway overview
  - Marketplaces overview
  - Indexer overview
- fix links that break with moving guides