### PR TITLE
Builder settings and collaborators

### DIFF
--- a/docs/075-guides/950-project-settings.mdx
+++ b/docs/075-guides/950-project-settings.mdx
@@ -2,87 +2,137 @@
 slug: /guides/managing-settings
 ---
 
-# Settings in Builder
+# Sequence Builder Settings
 
-once you are in setting, you have the options to change your:
-- **General settings** - update your [project name](#) or [avatar](#)
-- **Collaborators** - add [collaborators](#) or create [invite links](#)
-- **Networks** - update the [networks](#) your project is using
-- **API Access Keys** - create [new keys](#) and [configure existing keys](#)
-- **Billing** - update your [project plan](#) or set [overage limits](#)
+There are various actions available for your project in Settings of Sequence Builder.
 
-and finally, you can delete your project from settings as well.
+The Settings section in Sequence Builder is categorized into five smaller sections:
+1. **General**: Update your [project name](#) or [avatar](#).
+2. **Collaborators**: Add [collaborators](#) or create [invite links](#)
+3. **Networks**: Update the [networks](#) your project is using.
+4. **API Access Keys**: Create [new keys](#) and [configure existing keys](#)
+5. **Billing**: Update your [project plan](#) or set [overage limits](#)
+
+The final action you can take in settings is to delete your project.
+
+Settings are configured per-project, so navigate to the settings of a specific project.
+
+
+## 0. Getting to Settings in Builder
 
 #### Select a Project
 
+When you log into Sequence Builder, you will see a list of projects. If you haven't created a project yet, do so now.
+
+Begin by selecting a project.
+
+
+![Builder select Project](/img/builder/select-project.png)
 
 #### Go to Settings
 
+Now that you are in your project dashboard, click on 'Settings' on the left side of the screen.
+
+
+![Builder select Settings](/img/builder/select-settings.png)
+
+Within settings, you will find the five smaller sections covered in this guide.
+
+### Delete a Project
+
+To delete your project, make sure you selected the [correct project](#) and are in [Settings](#).
+
+You will need administrative-level permissions to delete a project. If you are an Admin, you will notice a section labeled 'Danger Zone' under all your settings sections.
+
+:::danger
+The following instructions are destructive and irreversible, so do not follow these steps unless you intend to delete your project.
+:::
+
+In this area, you will also find an option to 'Delete this Project' — click that option.
+
+
+![Builder delete project](/img/builder/delete-project.png)
+
+This action will prompt a modal to confirm that you want to delete your Project.
+
+Enter the name of your project and click the `Delete Permanently` button.
+
+
+![Builder delete project](/img/builder/delete-project-modal.png)
 
 
 
 
-## General Settings
+## 1. General Settings
 
 Open your General settings.
 
-// photo of clicking General settings
+
+![Builder settings select General](/img/builder/settings-select-general.png)
 
 In General you will find a couple of options.
 
 ##### Project Name
-The first option is to change your Project Name. To do so, enter a new project name in the field and hit the `update` button to save.
+The first option is to change your Project Name. To do so, enter a new project name in the field and hit the `Update` button to save.
 
 ##### Avatar
-The second option is to change your Project Avatar - which shows up in the top left corner of your project in the dashboard. Click the Avatar field to select an image and then hit the `update` button to save.
-
-// photo of general settings
+The second option allows you to modify your Project Avatar, visible in the top left corner of your project on the dashboard. Click the Avatar field to choose an image and then press the `Update` button to save your changes.
 
 
----
+![Builder settings General](/img/builder/settings-general.png)
 
 
 
-## Collaborator Settings
+
+## 2. Collaborator Settings
+
 
 Open your Collaborators settings.
 
-// photo of clicking Collaborator settings
 
-In Collaborator you have a couple of ways you can add collaborators to your team, which are to:
-- add a collaborator directly - enter their user address then select their access level.
-- create an invite link - select the access level, then set how long and how many times (optional) the link can be used.
+![Builder settings select Collaborators](/img/builder/settings-select-collaborators.png)
 
-next we'll walk you through how exactly you can do each of these things
+In the Collaborator settings, you have two methods to add collaborators to your project.
 
-// photo of collaborator settings
+The first method is to directly add collaborators by entering their information and selecting their access level.
+
+The second method is to create an invite link. When using this option, you can specify the access level, link duration, and optional usage limits.
+
+Let's walk through each of these processes step by step.
+
+
+![Builder settings Collaborators](/img/builder/settings-collaborators.png)
 
 ### Add a Collaborator 
 
-To add a collaborator - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [Collaborator Settings](#) section.
+To add a collaborator, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [Collaborator section](#).
+
 
 Start by clicking on the `Add Collaborator` button.
 
-// photo of collaborator selecting Add Collaborator
+
+![Builder settings Collaborators select Add Collaborator](/img/builder/settings-collaborators-select-add-collaborator.png)
 
 Enter a wallet address in the user address field, and then select the access level you want using the role dropdown.
 
 Finish by clicking the `Add new Collaborator` button.
 
-// photo of add collaborator modal
+
+![Builder settings Collaborators Add Collaborator modal](/img/builder/settings-collaborators-add-collaborator-modal.png)
 
 To confirm, you should see your new collaborator in the dashboard, including their wallet address and access level.
 
-// photo of new user added
 
+![Builder settings Collaborators confirm collaborator](/img/builder/settings-collaborators-confirm-collaborator.png)
 
 ### Create an Invite Link
 
-To add a collaborator through sharing an invite link - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [Collaborator Settings](#) section.
+To create an invite link, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [Collaborator section](#).
 
 Start by click on the the `Create Invite Link` button.
 
-// photo of collaborator selecting Create Invite Link
+
+![Builder settings Collaborators select Create Invite Link](/img/builder/settings-collaborators-select-create-invite-link.png)
 
 Start by selecting the access level you want your invite link to give: Read, Write, or Admin.
 
@@ -92,70 +142,69 @@ Finally, select the amount of time you want this link to be valid: a day, 3 days
 
 Finish by clicking the `Create Link` button.
 
-// photo of create link modal
+
+![Builder settings Collaborators Create Invite Link modal](/img/builder/settings-collaborators-create-invite-link-modal.png)
 
 To confirm, you should see your invite link in the dashboard, including the access level, limit, date created, and time remaining until it expires.
 
-// photo of link created in the dashboard
 
-#### Sharing the Invite Link
+![Builder settings Collaborators confirm invite link](/img/builder/settings-collaborators-confirm-invite-link.png)
+
+#### Sharing an Invite Link
 
 To share an invite link, click the `Copy Link` button.
 
 Go to where you want to share the link, paste it, and send it to your collaborators.
 
-// photo pointing to copy link in the dashboard
+
+![Builder settings Collaborators select copy link](/img/builder/settings-collaborators-select-copy-link.png)
 
 
-#### Deleting the Invite Link
+#### Deleting an Invite Link
 
 To remove an invite link, click the `Delete Link` button.
 
-// photo pointing to copy link in the dashboard
+
+![Builder settings Collaborators select delete link](/img/builder/settings-collaborators-select-delete-link.png)
 
 You will be prompted to confirm the deletion; click `Yes` to delete.
 
-// photo of delete confirmation
+
+![Builder settings Collaborators confirm delete modal](/img/builder/settings-collaborators-confirm-delete-modal.png)
 
 After deleting the link, you'll get a success notification at the bottom right of your dashboard, and the link will no longer be visible.
 
-// maybe photo of success modal
+
+![Builder settings Collaborators confirm invite deleted](/img/builder/settings-collaborators-confirm-invite-deleted.png)
 
 
 
 
-
-
-
-
-
-## Network Settings
+## 3. Network Settings
 
 Open your Network settings.
 
-// photo of clicking Network settings
 
-In your network settings, you'll find a list of networks supported by Sequence. This is where you can decide which networks you can:
-- access in the Node Gateway
-- deploy smart contracts on
+![Builder settings select Networks](/img/builder/settings-select-networks.png)
 
-Toggle the networks you would like to use and click the `Update` button.
+In the network settings, you'll see a list of supported networks in Sequence. Here, you can choose which networks you want to access through the Node Gateway and deploy smart contracts on.
 
-// photo of all the networks listed with toggles
+Toggle the networks you wish to use and then click the `Update` button.
 
 
+![Builder settings Networks](/img/builder/settings-networks.png)
 
 
 
 
-
-## API Access Keys Settings
+## 4. API Access Keys Settings
 
 Open your API Access Keys settings.
 
-// photo of clicking API Access settings
 
-When you open your API access key settings, you will see all the API keys that you have access to
+![Builder settings select API Access Keys](/img/builder/settings-select-api-access-keys.png)
+
+When accessing your API access key settings, you'll see a list of available API keys.
 
 
 Inside API Access Keys you will find a dashboard where you can manage your keys, set default keys, see details on each key, and view credits usage,
@@ -170,115 +219,129 @@ For each there, there is a number of things you may want to do for a specific ke
 - copy or change the credentials of your key
 - configure how and where your key can be used
 
+For each key, there are specific actions you might want to take, such as renaming or deleting, copying or changing credentials, and configuring how and where your key can be used.
 
 
-// some photo somewhere
+
+![Builder settings API Access Keys](/img/builder/settings-api-access-keys.png)
+
+
 ### Create a new API Access Key
 
-To create a new key - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+To create a new API Access Key, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
 
-Start by clicking on the `Add API Access Key` button.
+Start by clicking the `Add API Access Key` button.
 
-// photo pointing to the API Access Key
 
-Simply give the key a name, and click the `Add Access Key` button to generate a new key. 
+![Builder settings API Access Keys select add API Access Key](/img/builder/settings-api-access-keys-select-add-api-access-key.png)
 
-If you would like to configure any details of your key, you can do so by selecting and updating it from the dashboard.
+Simply provide a name for the key and click the `Add Access Key` button to generate a new key. 
 
-// photo entering Access Key name
+If you need to configure any details of your key, you can do so by selecting and updating it from the dashboard.
+
+Finish by clicking the `Add Access Key` button.
+
+
+![Builder settings API Access Keys add Api Access Key modal](/img/builder/settings-api-access-keys-add-api-access-key-modal.png)
 
 ### Rename or delete an API Access Key
 
-To rename or delete one of your keys - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+To rename or delete one of your keys, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
 
-Start by selecting the key you want to rename or delete to open up its details.
+Start by selecting the key and opening up its details.
 
-// photo clicking on a specific key
+
+![Builder settings API Access Keys select API key for rename](/img/builder/settings-api-access-keys-select-api-key-for-rename.png)
 
 ##### Renaming your key
 
-Find the name field, and enter a new name. 
+In the name field, and enter a new name. 
 
-Then click the `update` button.
+Then click the `Update` button.
 
-// photo pointing to name and pointing to update
+
+![Builder settings API Access Keys rename key](/img/builder/settings-api-access-keys-rename-key.png)
 
 ##### Deleting your key
 
-Click on the `Delete` button in the bottom left. 
+Click the `Delete` button in the bottom left. 
 
-// photo pointing to name and pointing to update
+
+![Builder settings API Access Keys delete key](/img/builder/settings-api-access-keys-delete-key.png)
+
 
 You will be prompted to confirm the deletion; click `Yes` to delete.
 
-// photo of modal for deletion
 
-
+![Builder settings API Access Keys delete key modal](/img/builder/settings-api-access-keys-delete-key-modal.png)
 
 ### Access the credentials of a Key
 
-To access the credentials of a key - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+To access the credentials of a key, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
 
-Start by selecting the key you want to access the credentials of.
+Start by selecting the key that you want to access the credentials for.
 
-// photo clicking on a specific key
+
+![Builder settings API Access Keys select api key](/img/builder/settings-api-access-keys-select-api-key.png)
 
 ##### Copy your Key
-You may want to copy your credentials so that you can securly paste them where you need to.
+Your API key is designed to be used in another location or application. To use it, you need to copy it here and paste it into your application.
 
-Click the `Copy` button in the Access Key field.
+To copy your keys credentials, click `Copy` in the Access Key field.
 
-After you click the button, it will transform into a button that says `✓ Copied` for about a second - confirming that you have successfully copied the credentials
+After clicking, you'll get confirmation when the button briefly changes to `✓ Copied`.
 
 Your key credentials are now copied to your clipboard.
 
-// photo pointing to the copy button
+
+![Builder settings API Access Keys copy key](/img/builder/settings-api-access-keys-copy-key.png)
 
 ##### Rotate your Key
-You may want to change the credentials without removing all the usage tracking history for a key you have been using.
+You may want to change your key credentials without losing usage history.
 
-Click the `Rotate` button in the Access Key field.
+To do this, click the `Rotate` button in the Access Key field.
 
-After you click the button, you will see the credentials change into new credentials and a success notification will show up in the bottom right of your screen for a couple of seconds - confirming that you have successfully rotated your key.
+After clicking, you'll see the credentials transform with a success notification in the bottom right.
 
-// photo pointing to the rotate button
+
+![Builder settings API Access Keys rotate key](/img/builder/settings-api-access-keys-rotate-key.png)
 
 ### Update API access settings of a Key
 
-To update API access settings of a key - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+To update API access settings of a key, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
 
-Start by selecting the key you want to update the access settings on.
-
-// photo clicking on a specific key
+Start by selecting the key that you want to update the access to.
 
 
+![Builder settings API Access Keys select api key](/img/builder/settings-api-access-keys-select-api-key.png)
 
 ##### Set domain access
-You may want to make sure the services enabled by your API key is being used domains associated with your game or app and not on other domains.
+Make sure your API key's services are only used on domains connected to your game or app. This can be done by setting the specific domains where your keys can be used.
 
-Enter the domain you want to have access to into the domain field.
+To do this, enter the domain you want to enable access to into the domain field.
 
-If you have another domain that you wish to add access to, click the `Add Domain` button. Then enter the other domain you want to have access to into that field.
+If you want to include another domain, click the `Add Domain` button and add it too. You should now have a list of domains your key can be used with.
 
-Continue clicking `Add Domain` and adding domains until you have included all the domains you need.
+Continue adding to this list until you have included all of the domains that you need.
 
-Finish by clicking the `Update button` to save.
+Complete your update by clicking the `Update button` to save.
 
-// photo of clicking add domain.
+
+![Builder settings API Access Keys add domains](/img/builder/settings-api-access-keys-add-domains.png)
 
 ##### Set service access
-You may want to make sure that specific services are enabled by your API key and not other services that we provide.
+You can set your API key to enable only specific services rather than all the services we offer.
 
-Near the bottom right you will find several services listed with checkboxes.
+To do this, look near the bottom right you will find several services listed with checkboxes.
+
+To do this, look for the checkboxes listing several services enabled by our key. Check the services that you want enabled for this key.
 
 Check the box for each service that you want your key to have access to.
 
-Finish by clicking the `Update button` to save.
-
-// photo of checking services.
+Complete your update by clicking the `Update button` to save.
 
 
-
+![Builder settings API Access Keys check services](/img/builder/settings-api-access-keys-check-services.png)
 
 
 ## Billing Settings

--- a/docs/075-guides/950-project-settings.mdx
+++ b/docs/075-guides/950-project-settings.mdx
@@ -367,6 +367,21 @@ In the billing section, you can quickly access key information about your subscr
 - Overage settings status
 
 
-### Update your project plan
+### Update your project subscription plan
+To update your project subscription plan, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [Billing section](#).
+
+Start by clicking on the `Upgrade Plan` button.
+
+![Builder settings billing select upgrade plan](/img/builder/settings-billing-select-upgrade-plan.png)
+
+This will take you to our plans screen where you can review the plans and select the one that works best for you.
+
+Once you know which plan you want, click the "Select Plan" button.
+
+![Builder settings billing upgrade plan dashboard](/img/builder/settings-billing-upgrade-plan-dashboard.png)
+
+This will take you to a checkout screen where you can enter your payment information.
+
+![Builder settings billing checkout](/img/builder/settings-billing-checkout.png)
 
 ### Set your overage limit

--- a/docs/075-guides/950-project-settings.mdx
+++ b/docs/075-guides/950-project-settings.mdx
@@ -1,0 +1,309 @@
+---
+slug: /guides/managing-settings
+---
+
+# Settings in Builder
+
+once you are in setting, you have the options to change your:
+- **General settings** - update your [project name](#) or [avatar](#)
+- **Collaborators** - add [collaborators](#) or create [invite links](#)
+- **Networks** - update the [networks](#) your project is using
+- **API Access Keys** - create [new keys](#) and [configure existing keys](#)
+- **Billing** - update your [project plan](#) or set [overage limits](#)
+
+and finally, you can delete your project from settings as well.
+
+#### Select a Project
+
+
+#### Go to Settings
+
+
+
+
+
+## General Settings
+
+Open your General settings.
+
+// photo of clicking General settings
+
+In General you will find a couple of options.
+
+##### Project Name
+The first option is to change your Project Name. To do so, enter a new project name in the field and hit the `update` button to save.
+
+##### Avatar
+The second option is to change your Project Avatar - which shows up in the top left corner of your project in the dashboard. Click the Avatar field to select an image and then hit the `update` button to save.
+
+// photo of general settings
+
+
+---
+
+
+
+## Collaborator Settings
+
+Open your Collaborators settings.
+
+// photo of clicking Collaborator settings
+
+In Collaborator you have a couple of ways you can add collaborators to your team, which are to:
+- add a collaborator directly - enter their user address then select their access level.
+- create an invite link - select the access level, then set how long and how many times (optional) the link can be used.
+
+next we'll walk you through how exactly you can do each of these things
+
+// photo of collaborator settings
+
+### Add a Collaborator 
+
+To add a collaborator - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [Collaborator Settings](#) section.
+
+Start by clicking on the `Add Collaborator` button.
+
+// photo of collaborator selecting Add Collaborator
+
+Enter a wallet address in the user address field, and then select the access level you want using the role dropdown.
+
+Finish by clicking the `Add new Collaborator` button.
+
+// photo of add collaborator modal
+
+To confirm, you should see your new collaborator in the dashboard, including their wallet address and access level.
+
+// photo of new user added
+
+
+### Create an Invite Link
+
+To add a collaborator through sharing an invite link - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [Collaborator Settings](#) section.
+
+Start by click on the the `Create Invite Link` button.
+
+// photo of collaborator selecting Create Invite Link
+
+Start by selecting the access level you want your invite link to give: Read, Write, or Admin.
+
+Enter the number of collaborators you want this link limitted to (setting a limit is optional).
+
+Finally, select the amount of time you want this link to be valid: a day, 3 days, or a week.
+
+Finish by clicking the `Create Link` button.
+
+// photo of create link modal
+
+To confirm, you should see your invite link in the dashboard, including the access level, limit, date created, and time remaining until it expires.
+
+// photo of link created in the dashboard
+
+#### Sharing the Invite Link
+
+To share an invite link, click the `Copy Link` button.
+
+Go to where you want to share the link, paste it, and send it to your collaborators.
+
+// photo pointing to copy link in the dashboard
+
+
+#### Deleting the Invite Link
+
+To remove an invite link, click the `Delete Link` button.
+
+// photo pointing to copy link in the dashboard
+
+You will be prompted to confirm the deletion; click `Yes` to delete.
+
+// photo of delete confirmation
+
+After deleting the link, you'll get a success notification at the bottom right of your dashboard, and the link will no longer be visible.
+
+// maybe photo of success modal
+
+
+
+
+
+
+
+
+
+## Network Settings
+
+Open your Network settings.
+
+// photo of clicking Network settings
+
+In your network settings, you'll find a list of networks supported by Sequence. This is where you can decide which networks you can:
+- access in the Node Gateway
+- deploy smart contracts on
+
+Toggle the networks you would like to use and click the `Update` button.
+
+// photo of all the networks listed with toggles
+
+
+
+
+
+
+
+## API Access Keys Settings
+
+Open your API Access Keys settings.
+
+// photo of clicking API Access settings
+
+When you open your API access key settings, you will see all the API keys that you have access to
+
+
+Inside API Access Keys you will find a dashboard where you can manage your keys, set default keys, see details on each key, and view credits usage,
+
+
+In the API Access Keys section, you'll find a dashboard to manage, set your default key, view details for each key, and monitor your credit usage.
+
+You can also add a new key or edit the details of an existing key.
+
+For each there, there is a number of things you may want to do for a specific key, like 
+- rename or delete your key
+- copy or change the credentials of your key
+- configure how and where your key can be used
+
+
+
+// some photo somewhere
+### Create a new API Access Key
+
+To create a new key - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+
+Start by clicking on the `Add API Access Key` button.
+
+// photo pointing to the API Access Key
+
+Simply give the key a name, and click the `Add Access Key` button to generate a new key. 
+
+If you would like to configure any details of your key, you can do so by selecting and updating it from the dashboard.
+
+// photo entering Access Key name
+
+### Rename or delete an API Access Key
+
+To rename or delete one of your keys - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+
+Start by selecting the key you want to rename or delete to open up its details.
+
+// photo clicking on a specific key
+
+##### Renaming your key
+
+Find the name field, and enter a new name. 
+
+Then click the `update` button.
+
+// photo pointing to name and pointing to update
+
+##### Deleting your key
+
+Click on the `Delete` button in the bottom left. 
+
+// photo pointing to name and pointing to update
+
+You will be prompted to confirm the deletion; click `Yes` to delete.
+
+// photo of modal for deletion
+
+
+
+### Access the credentials of a Key
+
+To access the credentials of a key - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+
+Start by selecting the key you want to access the credentials of.
+
+// photo clicking on a specific key
+
+##### Copy your Key
+You may want to copy your credentials so that you can securly paste them where you need to.
+
+Click the `Copy` button in the Access Key field.
+
+After you click the button, it will transform into a button that says `✓ Copied` for about a second - confirming that you have successfully copied the credentials
+
+Your key credentials are now copied to your clipboard.
+
+// photo pointing to the copy button
+
+##### Rotate your Key
+You may want to change the credentials without removing all the usage tracking history for a key you have been using.
+
+Click the `Rotate` button in the Access Key field.
+
+After you click the button, you will see the credentials change into new credentials and a success notification will show up in the bottom right of your screen for a couple of seconds - confirming that you have successfully rotated your key.
+
+// photo pointing to the rotate button
+
+### Update API access settings of a Key
+
+To update API access settings of a key - make sure you have selected the [right project](#), navigated [to Settings](#), and are in the [API Access Key](#) section.
+
+Start by selecting the key you want to update the access settings on.
+
+// photo clicking on a specific key
+
+
+
+##### Set domain access
+You may want to make sure the services enabled by your API key is being used domains associated with your game or app and not on other domains.
+
+Enter the domain you want to have access to into the domain field.
+
+If you have another domain that you wish to add access to, click the `Add Domain` button. Then enter the other domain you want to have access to into that field.
+
+Continue clicking `Add Domain` and adding domains until you have included all the domains you need.
+
+Finish by clicking the `Update button` to save.
+
+// photo of clicking add domain.
+
+##### Set service access
+You may want to make sure that specific services are enabled by your API key and not other services that we provide.
+
+Near the bottom right you will find several services listed with checkboxes.
+
+Check the box for each service that you want your key to have access to.
+
+Finish by clicking the `Update button` to save.
+
+// photo of checking services.
+
+
+
+
+
+## Billing Settings
+
+Open your Billing settings.
+
+// photo of clicking Billing settings
+
+In here, you are given all of subscription plan information that you need. 
+
+You can also update your subscription, and set your overage limits
+
+##### Billing information
+In the billing section, you can quickly access key information about your subscription plan:
+
+- Current subscription plan
+- Current billing period dates
+- Monthly billing amount
+- Next renewal date
+- Monthly credits issued
+- Credits used in the current period
+- Remaining credits
+- Overage settings status
+
+
+### Update your project plan
+
+### Set your overage limit

--- a/docs/075-guides/950-project-settings.mdx
+++ b/docs/075-guides/950-project-settings.mdx
@@ -1,24 +1,26 @@
 ---
 slug: /guides/managing-settings
+title: "Sequence Builder Settings"
 ---
 
-# Sequence Builder Settings
+## Settings Options
 
 There are various actions available for your project in Settings of Sequence Builder.
 
 The Settings section in Sequence Builder is categorized into five smaller sections:
-1. **General**: Update your [project name](#) or [avatar](#).
-2. **Collaborators**: Add [collaborators](#) or create [invite links](#)
-3. **Networks**: Update the [networks](#) your project is using.
-4. **API Access Keys**: Create [new keys](#) and [configure existing keys](#)
-5. **Billing**: Update your [project plan](#) or set [overage limits](#)
+1. **General**: Update your [project name](/guides/managing-settings#project-name) or [avatar](/guides/managing-settings#avatar)
+2. **Collaborators**: Add [collaborators](/guides/managing-settings#add-a-collaborator) or create [invite links](/guides/managing-settings#create-an-invite-link)
+3. **Networks**: Update the [networks](/guides/managing-settings#3-network-settings) your project is using
+4. **API Access Keys**: Create [new keys](/guides/managing-settings#create-a-new-api-access-key) and [configure existing keys](/guides/managing-settings#update-api-access-settings-of-a-key)
+5. **Billing**: Update your [project plan](/guides/managing-settings#update-your-project-subscription-plan) or set [overage limits](/guides/managing-settings#set-your-overage-limit)
 
-The final action you can take in settings is to delete your project.
+The final action you can take in settings is to [delete your project](/guides/managing-settings#delete-a-project).
 
-Settings are configured per-project, so navigate to the settings of a specific project.
+Settings are configured per project, so let's start by navigating to the settings of a specific project.
 
-
+---
 ## 0. Getting to Settings in Builder
+
 
 #### Select a Project
 
@@ -40,13 +42,13 @@ Within settings, you will find the five smaller sections covered in this guide.
 
 ### Delete a Project
 
-To delete your project, make sure you selected the [correct project](#) and are in [Settings](#).
-
-You will need administrative-level permissions to delete a project. If you are an Admin, you will notice a section labeled 'Danger Zone' under all your settings sections.
-
 :::danger
 The following instructions are destructive and irreversible, so do not follow these steps unless you intend to delete your project.
 :::
+
+To delete your project, make sure you have selected the [correct project](/guides/managing-settings#select-a-project) and are in the [Settings](/guides/managing-settings#go-to-settings) section. You will also need administrative-level permissions to delete a project. 
+
+If you are an Admin, you will notice a section labeled 'Danger Zone' under all your settings sections.
 
 In this area, you will also find an option to 'Delete this Project' — click that option.
 
@@ -62,7 +64,7 @@ Enter the name of your project and click the `Delete Permanently` button.
 
 
 
-
+---
 ## 1. General Settings
 
 Open your General settings.
@@ -70,7 +72,7 @@ Open your General settings.
 
 ![Builder settings select General](/img/builder/settings-select-general.png)
 
-In General you will find a couple of options.
+In General settings, you will find a couple of options.
 
 ##### Project Name
 The first option is to change your Project Name. To do so, enter a new project name in the field and hit the `Update` button to save.
@@ -83,7 +85,7 @@ The second option allows you to modify your Project Avatar, visible in the top l
 
 
 
-
+---
 ## 2. Collaborator Settings
 
 
@@ -98,14 +100,14 @@ The first method is to directly add collaborators by entering their information 
 
 The second method is to create an invite link. When using this option, you can specify the access level, link duration, and optional usage limits.
 
-Let's walk through each of these processes step by step.
+Let's walk through each of these.
 
 
 ![Builder settings Collaborators](/img/builder/settings-collaborators.png)
 
 ### Add a Collaborator 
 
-To add a collaborator, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [Collaborator section](#).
+To add a collaborator, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [Collaborators](/guides/managing-settings#2-collaborator-settings) section.
 
 
 Start by clicking on the `Add Collaborator` button.
@@ -127,7 +129,7 @@ To confirm, you should see your new collaborator in the dashboard, including the
 
 ### Create an Invite Link
 
-To create an invite link, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [Collaborator section](#).
+To create an invite link, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [Collaborators](/guides/managing-settings#2-collaborator-settings) section.
 
 Start by click on the the `Create Invite Link` button.
 
@@ -136,7 +138,7 @@ Start by click on the the `Create Invite Link` button.
 
 Start by selecting the access level you want your invite link to give: Read, Write, or Admin.
 
-Enter the number of collaborators you want this link limitted to (setting a limit is optional).
+Enter the number of collaborators you want this link to be limitted to (setting a limit is optional).
 
 Finally, select the amount of time you want this link to be valid: a day, 3 days, or a week.
 
@@ -179,7 +181,7 @@ After deleting the link, you'll get a success notification at the bottom right o
 
 
 
-
+---
 ## 3. Network Settings
 
 Open your Network settings.
@@ -196,7 +198,7 @@ Toggle the networks you wish to use and then click the `Update` button.
 
 
 
-
+---
 ## 4. API Access Keys Settings
 
 Open your API Access Keys settings.
@@ -204,38 +206,28 @@ Open your API Access Keys settings.
 
 ![Builder settings select API Access Keys](/img/builder/settings-select-api-access-keys.png)
 
-When accessing your API access key settings, you'll see a list of available API keys.
-
-
-Inside API Access Keys you will find a dashboard where you can manage your keys, set default keys, see details on each key, and view credits usage,
-
-
-In the API Access Keys section, you'll find a dashboard to manage, set your default key, view details for each key, and monitor your credit usage.
+In the API Access Keys section, you will find a dashboard with several options: monitor the usage of each key, set your default key, or expand the details of a specific key.
 
 You can also add a new key or edit the details of an existing key.
-
-For each there, there is a number of things you may want to do for a specific key, like 
-- rename or delete your key
-- copy or change the credentials of your key
-- configure how and where your key can be used
-
-For each key, there are specific actions you might want to take, such as renaming or deleting, copying or changing credentials, and configuring how and where your key can be used.
-
 
 
 ![Builder settings API Access Keys](/img/builder/settings-api-access-keys.png)
 
+For each key, there are specific actions you might want to take, such as:
+- [rename](/guides/managing-settings#renaming-your-key) or [delete](/guides/managing-settings#deleting-your-key) your key
+- [copy](/guides/managing-settings#copy-your-key) or [change](/guides/managing-settings#rotate-your-key) the credentials of your key
+- configure [how](/guides/managing-settings#set-service-access) and [where](/guides/managing-settings#set-domain-access) your key can be used
 
 ### Create a new API Access Key
 
-To create a new API Access Key, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
+To create a new API Access Key, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [API Access Key](/guides/managing-settings#4-api-access-keys-settings) section.
 
 Start by clicking the `Add API Access Key` button.
 
 
 ![Builder settings API Access Keys select add API Access Key](/img/builder/settings-api-access-keys-select-add-api-access-key.png)
 
-Simply provide a name for the key and click the `Add Access Key` button to generate a new key. 
+Provide a name for the key and click the `Add Access Key` button to generate a new key. 
 
 If you need to configure any details of your key, you can do so by selecting and updating it from the dashboard.
 
@@ -246,9 +238,9 @@ Finish by clicking the `Add Access Key` button.
 
 ### Rename or delete an API Access Key
 
-To rename or delete one of your keys, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
+To rename or delete one of your keys, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [API Access Key](/guides/managing-settings#4-api-access-keys-settings) section.
 
-Start by selecting the key and opening up its details.
+Start by selecting the key you want to edit.
 
 
 ![Builder settings API Access Keys select API key for rename](/img/builder/settings-api-access-keys-select-api-key-for-rename.png)
@@ -277,7 +269,7 @@ You will be prompted to confirm the deletion; click `Yes` to delete.
 
 ### Access the credentials of a Key
 
-To access the credentials of a key, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
+To access the credentials of a key, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [API Access Key](/guides/managing-settings#4-api-access-keys-settings) section.
 
 Start by selecting the key that you want to access the credentials for.
 
@@ -297,7 +289,7 @@ Your key credentials are now copied to your clipboard.
 ![Builder settings API Access Keys copy key](/img/builder/settings-api-access-keys-copy-key.png)
 
 ##### Rotate your Key
-You may want to change your key credentials without losing usage history.
+You may want to change your key credentials without losing all of its usage history.
 
 To do this, click the `Rotate` button in the Access Key field.
 
@@ -308,7 +300,7 @@ After clicking, you'll see the credentials transform with a success notification
 
 ### Update API access settings of a Key
 
-To update API access settings of a key, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [API Access Key section](#).
+To update API access settings of a key, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [API Access Key](/guides/managing-settings#4-api-access-keys-settings) section.
 
 Start by selecting the key that you want to update the access to.
 
@@ -316,9 +308,9 @@ Start by selecting the key that you want to update the access to.
 ![Builder settings API Access Keys select api key](/img/builder/settings-api-access-keys-select-api-key.png)
 
 ##### Set domain access
-Make sure your API key's services are only used on domains connected to your game or app. This can be done by setting the specific domains where your keys can be used.
+You can ensure that the services linked to your API key are only utilized on domains connected to your game or app by enabling specific domains where your keys can be used.
 
-To do this, enter the domain you want to enable access to into the domain field.
+To do this, enter a domain you want to enable access to into the domain field.
 
 If you want to include another domain, click the `Add Domain` button and add it too. You should now have a list of domains your key can be used with.
 
@@ -334,8 +326,6 @@ You can set your API key to enable only specific services rather than all the se
 
 To do this, look near the bottom right you will find several services listed with checkboxes.
 
-To do this, look for the checkboxes listing several services enabled by our key. Check the services that you want enabled for this key.
-
 Check the box for each service that you want your key to have access to.
 
 Complete your update by clicking the `Update button` to save.
@@ -343,16 +333,16 @@ Complete your update by clicking the `Update button` to save.
 
 ![Builder settings API Access Keys check services](/img/builder/settings-api-access-keys-check-services.png)
 
-
-## Billing Settings
+---
+## 5. Billing Settings
 
 Open your Billing settings.
 
-// photo of clicking Billing settings
+![Builder settings select Billing](/img/builder/settings-select-billing.png)
 
 In here, you are given all of subscription plan information that you need. 
 
-You can also update your subscription, and set your overage limits
+You can also [update your subscription](/guides/managing-settings#update-your-project-subscription-plan), and [set your overage limits](/guides/managing-settings#set-your-overage-limit).
 
 ##### Billing information
 In the billing section, you can quickly access key information about your subscription plan:
@@ -368,15 +358,15 @@ In the billing section, you can quickly access key information about your subscr
 
 
 ### Update your project subscription plan
-To update your project subscription plan, be sure you are in the [correct project](#), accessed [Settings](#), and are in the [Billing section](#).
+To update your project subscription plan, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [Billing](/guides/managing-settings#5-billing-settings) section.
 
 Start by clicking on the `Upgrade Plan` button.
 
 ![Builder settings billing select upgrade plan](/img/builder/settings-billing-select-upgrade-plan.png)
 
-This will take you to our plans screen where you can review the plans and select the one that works best for you.
+This will take you to our plans dashboard, where you can review the plans and select the one that works best for you.
 
-Once you know which plan you want, click the "Select Plan" button.
+Once you know which plan you want, click the `Select Plan` button.
 
 ![Builder settings billing upgrade plan dashboard](/img/builder/settings-billing-upgrade-plan-dashboard.png)
 

--- a/docs/075-guides/950-project-settings.mdx
+++ b/docs/075-guides/950-project-settings.mdx
@@ -385,3 +385,16 @@ This will take you to a checkout screen where you can enter your payment informa
 ![Builder settings billing checkout](/img/builder/settings-billing-checkout.png)
 
 ### Set your overage limit
+To set your overage limit, make sure you have selected the [correct project](/guides/managing-settings#select-a-project), accessed [Settings](/guides/managing-settings#go-to-settings), and are in the [Billing](/guides/managing-settings#5-billing-settings) section. you will also need a paid plan to set an overage limit.
+
+With a paid plan, start by clicking on the button with the gear icon.
+
+![Builder settings billing set overage](/img/builder/settings-billing-set-overage.png)
+
+Toggle the 'Set overage limit' option.
+
+Then enter the maximum overage amount that you would like to set.
+
+Finish by clicking the `Save changes` button.
+
+![Builder settings billing overage modal](/img/builder/settings-billing-overage-modal.png)

--- a/docs/100-builder/800-project-settings.mdx
+++ b/docs/100-builder/800-project-settings.mdx
@@ -1,7 +1,10 @@
 ---
-slug: /guides/managing-settings
-title: "Sequence Builder Settings"
+title: "Settings and Collaborators"
+hide_title: true
+slug: /builder/settings-collaborators
 ---
+
+# Settings and Collaborators in Builder
 
 ## Settings Options
 
@@ -19,7 +22,7 @@ The final action you can take in settings is to [delete your project](/guides/ma
 Settings are configured per project, so let's start by navigating to the settings of a specific project.
 
 ---
-## 0. Getting to Settings in Builder
+## Getting to Settings in Builder
 
 
 #### Select a Project
@@ -388,3 +391,5 @@ Then enter the maximum overage amount that you would like to set.
 Finish by clicking the `Save changes` button.
 
 ![Builder settings billing overage modal](/img/builder/settings-billing-overage-modal.png)
+
+

--- a/docs/100-builder/800-project-settings.mdx
+++ b/docs/100-builder/800-project-settings.mdx
@@ -43,29 +43,6 @@ Now that you are in your project dashboard, click on 'Settings' on the left side
 
 Within settings, you will find the five smaller sections covered in this guide.
 
-### Delete a Project
-
-:::danger
-The following instructions are destructive and irreversible, so do not follow these steps unless you intend to delete your project.
-:::
-
-To delete your project, make sure you have selected the [correct project](/guides/managing-settings#select-a-project) and are in the [Settings](/guides/managing-settings#go-to-settings) section. You will also need administrative-level permissions to delete a project. 
-
-If you are an Admin, you will notice a section labeled 'Danger Zone' under all your settings sections.
-
-In this area, you will also find an option to 'Delete this Project' — click that option.
-
-
-![Builder delete project](/img/builder/delete-project.png)
-
-This action will prompt a modal to confirm that you want to delete your Project.
-
-Enter the name of your project and click the `Delete Permanently` button.
-
-
-![Builder delete project](/img/builder/delete-project-modal.png)
-
-
 
 ---
 ## 1. General Settings
@@ -392,4 +369,26 @@ Finish by clicking the `Save changes` button.
 
 ![Builder settings billing overage modal](/img/builder/settings-billing-overage-modal.png)
 
+---
 
+## Delete a Project
+
+:::danger
+The following instructions are destructive and irreversible, so do not follow these steps unless you intend to delete your project.
+:::
+
+To delete your project, make sure you have selected the [correct project](/guides/managing-settings#select-a-project) and are in the [Settings](/guides/managing-settings#go-to-settings) section. You will also need administrative-level permissions to delete a project. 
+
+If you are an Admin, you will notice a section labeled 'Danger Zone' under all your settings sections.
+
+In this area, you will also find an option to 'Delete this Project' — click that option.
+
+
+![Builder delete project](/img/builder/delete-project.png)
+
+This action will prompt a modal to confirm that you want to delete your Project.
+
+Enter the name of your project and click the `Delete Permanently` button.
+
+
+![Builder delete project](/img/builder/delete-project-modal.png)

--- a/static/img/builder/delete-project-modal.png
+++ b/static/img/builder/delete-project-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d919343ec5000995005571abc97a72c25d9cdb0e110e563e877a61075cc96a6
+size 74427

--- a/static/img/builder/delete-project.png
+++ b/static/img/builder/delete-project.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d628f15604988efcfad42bb4fe9ada8a6f257835ef83b8b7d808a1d9af545da
+size 137529

--- a/static/img/builder/select-project.png
+++ b/static/img/builder/select-project.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee35416d7c228e91aae6edfedd81847774fff360e31f6cb0150037c75141456
+size 107308

--- a/static/img/builder/select-settings.png
+++ b/static/img/builder/select-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142eacfb6d98ca7c5462699e156ac81e80c7424170f2bb71367aff4f17cf5a77
+size 116467

--- a/static/img/builder/settings-api-access-keys-add-api-access-key-modal.png
+++ b/static/img/builder/settings-api-access-keys-add-api-access-key-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e440abfc44a4006e35a12fc52c8cd8240887f31906b44a51711df91a96fd884
+size 87535

--- a/static/img/builder/settings-api-access-keys-add-domains.png
+++ b/static/img/builder/settings-api-access-keys-add-domains.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51a709518430149046a5d38fa2ec1bb7ada8363276d98a2f61f7d88807e7c98d
+size 164933

--- a/static/img/builder/settings-api-access-keys-check-services.png
+++ b/static/img/builder/settings-api-access-keys-check-services.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69807fb5827291b5918a18729a9dffb603e12d6166dedcc2fe3c1cf3e7c7a121
+size 170296

--- a/static/img/builder/settings-api-access-keys-copy-key.png
+++ b/static/img/builder/settings-api-access-keys-copy-key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3ec70a83c4d066d6f9599aea91d6ddc975b542c60e13a39e4e448c353ace3ce
+size 139967

--- a/static/img/builder/settings-api-access-keys-delete-key-modal.png
+++ b/static/img/builder/settings-api-access-keys-delete-key-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f37e04262fccede6cf98e2f719c9bf4074d28428186d08ded6f0fa5c80d5a7c0
+size 89042

--- a/static/img/builder/settings-api-access-keys-delete-key.png
+++ b/static/img/builder/settings-api-access-keys-delete-key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abdecad8ed6d82a3b9f88b7728dac88843f44506b85a5207a9f4d9a5aec329a1
+size 135248

--- a/static/img/builder/settings-api-access-keys-rename-key.png
+++ b/static/img/builder/settings-api-access-keys-rename-key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00e28ea6ede19fefd258eebd258b1c30275e2c6960bad963e89746848205e8f
+size 157493

--- a/static/img/builder/settings-api-access-keys-rotate-key.png
+++ b/static/img/builder/settings-api-access-keys-rotate-key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4967226273cfadbea9dfffb5b64ff137c98f5ab1bd95a6dff58201f10aee1789
+size 140748

--- a/static/img/builder/settings-api-access-keys-select-add-api-access-key.png
+++ b/static/img/builder/settings-api-access-keys-select-add-api-access-key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3108421c637b670835a9a2bfd588dc63ae37a654417e235378afa578d085f92e
+size 126898

--- a/static/img/builder/settings-api-access-keys-select-api-key-for-rename.png
+++ b/static/img/builder/settings-api-access-keys-select-api-key-for-rename.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e9b90fa659c59b8c6b1a9526bdf0c153f89855035eb6c543fe3f316f8c3c633
+size 117761

--- a/static/img/builder/settings-api-access-keys-select-api-key.png
+++ b/static/img/builder/settings-api-access-keys-select-api-key.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c29eb648983a4d5865e46e259d0f762720c53c4cc97c3e3338ec95b0374710e
+size 120834

--- a/static/img/builder/settings-api-access-keys.png
+++ b/static/img/builder/settings-api-access-keys.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b385442b0e556709c6907955b373e90464ff7820c691dedf785cc00e8a92b88c
+size 93134

--- a/static/img/builder/settings-billing-checkout.png
+++ b/static/img/builder/settings-billing-checkout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1f4c30987532d3d581895e18e678eba9a1bc61e7f48a86aa9bfec3792eee3e1
+size 114252

--- a/static/img/builder/settings-billing-overage-modal.png
+++ b/static/img/builder/settings-billing-overage-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57f01ba148cf14f49602c75982c16aadad8dc16b3032ac45982b67b70313e2ab
+size 77343

--- a/static/img/builder/settings-billing-select-upgrade-plan.png
+++ b/static/img/builder/settings-billing-select-upgrade-plan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eec32101e38223ec3557bebb7bfe6812a667a9dfd0d3283b40dc06be07c75011
+size 134292

--- a/static/img/builder/settings-billing-set-overage.png
+++ b/static/img/builder/settings-billing-set-overage.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c78056b2af9c86ad22e302b3b8855ad6c2903de836a11aac2ec0501ea7cb6fdf
+size 121992

--- a/static/img/builder/settings-billing-upgrade-plan-dashboard.png
+++ b/static/img/builder/settings-billing-upgrade-plan-dashboard.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37370a07b30b458fb79c4da7737bbf9102356a87a27e9d791c4fe085c802b7f0
+size 262604

--- a/static/img/builder/settings-collaborators-add-collaborator-modal.png
+++ b/static/img/builder/settings-collaborators-add-collaborator-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6caaf2cbb8b76b76790e299ba9067b14f0c82643953b5401571c4bac9df1cd4
+size 85109

--- a/static/img/builder/settings-collaborators-confirm-collaborator.png
+++ b/static/img/builder/settings-collaborators-confirm-collaborator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbfd7d75d007fab4d03ec4e4e7e83e28945c05efc728b67884f62272e863211
+size 92591

--- a/static/img/builder/settings-collaborators-confirm-delete-modal.png
+++ b/static/img/builder/settings-collaborators-confirm-delete-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85bbde81e63b1ac02bf1d9d783ead3f7f9c29e1893696cf752e74dec85d5462d
+size 79321

--- a/static/img/builder/settings-collaborators-confirm-invite-deleted.png
+++ b/static/img/builder/settings-collaborators-confirm-invite-deleted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7135d87b76bb6cb3bc1dbbcafbcd25795113540ea690e58c1dd2d8643f5bea34
+size 97973

--- a/static/img/builder/settings-collaborators-confirm-invite-link.png
+++ b/static/img/builder/settings-collaborators-confirm-invite-link.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df9d9fafe2362a506b831f664897497a1495cc580a3b0fb335024c1799267e7b
+size 116238

--- a/static/img/builder/settings-collaborators-create-invite-link-modal.png
+++ b/static/img/builder/settings-collaborators-create-invite-link-modal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72c94b67b022ea276c31ce9601dbc5482d10627d07fab32bcd02ce1e1ce401a1
+size 89185

--- a/static/img/builder/settings-collaborators-select-add-collaborator.png
+++ b/static/img/builder/settings-collaborators-select-add-collaborator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ad1089a6363db25ab13c7e3a2a1dd001181c66c2245841ab97b032a979c3710
+size 108644

--- a/static/img/builder/settings-collaborators-select-copy-link.png
+++ b/static/img/builder/settings-collaborators-select-copy-link.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ce372cbd6f4db5cfbf9c0f1d919e2539bbfc4912423a9bf298d4c25161c583d
+size 128575

--- a/static/img/builder/settings-collaborators-select-create-invite-link.png
+++ b/static/img/builder/settings-collaborators-select-create-invite-link.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcc9defd4a8ab6e11ac1a88e67de8129a24e278eabf8518e35f0fcec2c878a56
+size 114176

--- a/static/img/builder/settings-collaborators-select-delete-link.png
+++ b/static/img/builder/settings-collaborators-select-delete-link.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d497c3f2f34555f61af22c077e54f1fb7d2e2ae9981e7246b2ceefcf89df24b
+size 124309

--- a/static/img/builder/settings-collaborators.png
+++ b/static/img/builder/settings-collaborators.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00d450f0460a803d2c755effa2321c0679dc71d0e81d273db62d9e15090fa671
+size 82454

--- a/static/img/builder/settings-general.png
+++ b/static/img/builder/settings-general.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d8ff8c299771f13f4db8b144feab8ff2b64d4064f3cca69fa4b8ef1be840368
+size 82900

--- a/static/img/builder/settings-networks.png
+++ b/static/img/builder/settings-networks.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa3d34e4f9a7c74a0fbf7adcc0bbd5c9ba8ffa70b7cce4cad6d3e27a0141c4c7
+size 152477

--- a/static/img/builder/settings-select-api-access-keys.png
+++ b/static/img/builder/settings-select-api-access-keys.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ae871ec13c40d76d831b58ec34d80b11c6b2b99672c12f5bf11ecd8442f87cb
+size 138833

--- a/static/img/builder/settings-select-billing.png
+++ b/static/img/builder/settings-select-billing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48d3f2f8f1689fc22f1e71c3340e1c37724fba0a3906d1d3f60e941c57d216fc
+size 136879

--- a/static/img/builder/settings-select-collaborators.png
+++ b/static/img/builder/settings-select-collaborators.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:295e5928608b21f1fbcba9f82c36106301be10f03c8315f70bc5004e4661cb24
+size 144238

--- a/static/img/builder/settings-select-general.png
+++ b/static/img/builder/settings-select-general.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89be730a1b6b3fb1e904e7c72bf7c8a75da4dd407e3dd868aa5f186856ac81d2
+size 144572

--- a/static/img/builder/settings-select-networks.png
+++ b/static/img/builder/settings-select-networks.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9cecfc1f97b49af94b1de7a2f6faa8c30f0c693ebce4b7a6dbdd5cc06b4585f
+size 140880


### PR DESCRIPTION
This is the commit where we're trying out the new "manual" format for a section in Builder. The section for this one is "Settings and Collaborators".

In our original format for step-by-steps, we focused on writing a doc for a specific action - but with each action taking several steps to reach the end point, we spent a lot of time repeating the first steps over several different docs.

The aim of using a manual was to remove this repetition and put all the things you would want to know how to do in a specific section of builder into one doc. This will also leverage the top right sidebar better.

The potential drawbacks are that manuals might get a bit congested, and it may affect the flow of the step-by-steps substantially.

FWIW - I believe 'Settings and Collaborators' is the most complex of all the sections. If the manual us understandable for this section, it should be easier to understand for the other sections we make it for as they are less complex.

Here is a list of the potential step-by-step guides that using this manual is consolidating into one document:
- How to Delete a Project
- How to Add a Collaborator
- How to Create an Invite Link
- How to Create a new API Access Key
- How to Rename or delete an API Access Key
- How to Access the credentials of an API Access Key
- How to Update API access settings of an API Access Key
- How to Update your project subscription plan
- How to Set your overage limit