### PR TITLE
Update package manager install link

### DIFF
--- a/docs/unity-waas-sdk/02-installation.mdx
+++ b/docs/unity-waas-sdk/02-installation.mdx
@@ -5,7 +5,7 @@
 1. Ensure you have Git 2.14.0 or above installed on your machine
 2. Open Package Manager (Window > Package Manager)
 3. Click the "+" icon in the Package Manager window > "Add package from git URL..."
-4. Paste this url and click Add or press Enter on your keyboard `https://github.com/0xsequence/sequence-unity.git?path=/Assets#v2.0.0`
+4. Paste this url and click Add or press Enter on your keyboard `https://github.com/0xsequence/sequence-unity.git?path=/Assets`
 5. From Package Manager, click on "Samples"
 6. Import "Setup" from Samples
 ![Setup](/img/unity/unity-import-setup.png)


### PR DESCRIPTION
Now that our package manager integration has been merged to master, we no longer need to specify the tag when importing the sdk. This will also allow devs to update to the newest version using the update button in package manager